### PR TITLE
Adds index.coffee so that the scripts get loaded

### DIFF
--- a/index.coffee
+++ b/index.coffee
@@ -1,0 +1,12 @@
+fs = require 'fs'
+path = require 'path'
+
+module.exports = (robot, scripts) ->
+  scriptsPath = path.resolve(__dirname, 'src')
+  fs.exists scriptsPath, (exists) ->
+    if exists
+      for script in fs.readdirSync(scriptsPath)
+        if scripts? and '*' not in scripts
+          robot.loadFile(scriptsPath, script) if script in scripts
+        else
+          robot.loadFile(scriptsPath, script)


### PR DESCRIPTION
This fixes the load issue.

In packages.json you specifiy a 'main' file. That's the only one that gets loaded by default.

This fix adds index.coffee which in turn loads everything inside the `src` folder.
